### PR TITLE
Add back __typename for new TodoEdge

### DIFF
--- a/examples/todo/js/subscriptions/AddTodoSubscription.js
+++ b/examples/todo/js/subscriptions/AddTodoSubscription.js
@@ -13,6 +13,7 @@ export default class AddTodoSubscription extends RelaySubscriptions.Subscription
     return Relay.QL`subscription {
       addTodoSubscription {
         todoEdge {
+          __typename
           node {
             id
             text


### PR DESCRIPTION
This works around an issue that was fixed for mutations in https://github.com/facebook/relay/pull/657.
